### PR TITLE
Update log file rotation functionality

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/hibp_py"]
 
 [project]
 name = "hibp-py"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = ["python-dotenv", "requests"]
 authors = [{ name = "Pavel Sushko", email = "github@psushko.com" }]
 description = "Python utility for Have I Been Pwned API"

--- a/src/hibp_py/__main__.py
+++ b/src/hibp_py/__main__.py
@@ -8,11 +8,13 @@ import time
 
 def main():
     config = utils.load_config()
+    logger = utils.Logger()
 
-    if 'LOG_PATH' in config.keys():
-        logger = utils.Logger(config['LOG_PATH'])
-    else:
-        logger = utils.Logger()
+    if 'LOG_PATH' in config:
+        logger.__setattr__('path', config['LOG_PATH'])
+
+    if 'ROTATION_SIZE' in config:
+        logger.__setattr__('rotation_size', config['ROTATION_SIZE'])
 
     print('Welcome to HIBP Python!')
 

--- a/src/hibp_py/utils.py
+++ b/src/hibp_py/utils.py
@@ -24,8 +24,9 @@ def handle_rate_limit(logger):
 
 
 class Logger:
-    def __init__(self, path="events.log"):
+    def __init__(self, path="events.log", rotation_size=1000):
         self.path = path
+        self.rotation_size = rotation_size
 
     def log_event(self, event, severity="INFO"):
         """Log an event to a file
@@ -39,7 +40,7 @@ class Logger:
         print(event_str)
 
         with open(self.path, 'r+', encoding='utf-8') as f:
-            if len(f.readlines()) >= 1000:
+            if len(f.readlines()) >= self.rotation_size:
                 self.rotate()
 
             f.write(event_str + '\n')

--- a/src/hibp_py/utils.py
+++ b/src/hibp_py/utils.py
@@ -39,7 +39,7 @@ class Logger:
         print(event_str)
 
         with open(self.path, 'r+', encoding='utf-8') as f:
-            if len(f.readlines()) >= 10:
+            if len(f.readlines()) >= 1000:
                 self.rotate()
 
             f.write(event_str + '\n')


### PR DESCRIPTION
The log file rotation functionality has been improved in this pull request. The log file size threshold for rotation has been increased to 1000 lines. Users can now also set a custom rotation size via the config.json file. The version has been updated to 1.2.1.