### PR TITLE
Refactor email sending logic to use config for test recipient

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/hibp_py"]
 
 [project]
 name = "hibp-py"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = ["python-dotenv", "requests"]
 authors = [{ name = "Pavel Sushko", email = "github@psushko.com" }]
 description = "Python utility for Have I Been Pwned API"

--- a/src/hibp_py/mail.py
+++ b/src/hibp_py/mail.py
@@ -15,9 +15,6 @@ FROM_NAME = config['FROM_NAME']
 FROM_EMAIL = config['FROM_EMAIL']
 SUBJECT = config['SUBJECT']
 
-if 'TEST_RECIPIENT' in config.keys():
-    TEST_RECIPIENT = config['TEST_RECIPIENT']
-
 
 def send_email(email, body):
     """Send an email
@@ -26,8 +23,8 @@ def send_email(email, body):
         email (str): The recipient's email address
         body (str): The email body
     """
-    if TEST_RECIPIENT:
-        email = TEST_RECIPIENT
+    if 'TEST_RECIPIENT' in config.keys():
+        email = config['TEST_RECIPIENT']
 
     message = MIMEMultipart('alternative')
     message['Subject'] = SUBJECT


### PR DESCRIPTION
This pull request refactors the email sending logic to use the config file for the test recipient. This fixes the error that occurs when the TEST_RECIPIENT is not defined. Additionally, the version is updated to 1.2.2.

Fixes #33