### PR TITLE
Refactor write_breach function and bump version to 1.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["src/hibp_py"]
 
 [project]
 name = "hibp-py"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = ["python-dotenv", "requests"]
 authors = [{ name = "Pavel Sushko", email = "github@psushko.com" }]
 description = "Python utility for Have I Been Pwned API"

--- a/src/hibp_py/db.py
+++ b/src/hibp_py/db.py
@@ -74,8 +74,9 @@ def write_breach(user, breach):
         new_breach = True
         users[user].append(breach['Name'])
 
-    with open(USERS_FILE, 'w', encoding='utf-8') as f:
-        json.dump(users, f, sort_keys=True)
+    if new_breach:
+        with open(USERS_FILE, 'w', encoding='utf-8') as f:
+            json.dump(users, f, sort_keys=True)
 
     if os.path.isfile(BREACHES_FILE):
         with open(BREACHES_FILE, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
The `write_breach` function has been refactored to only write to the `USERS_FILE` if a new breach is detected. Additionally, the version in `pyproject.toml` has been bumped to 1.2.5.